### PR TITLE
v0.17.0

### DIFF
--- a/python-rasterstats.spec
+++ b/python-rasterstats.spec
@@ -5,17 +5,34 @@
 %endif
 
 Name:           python-rasterstats
-Version:        0.13.1
-Release:        2%{?dist}
+Version:        0.17.0
+Release:        1%{?dist}
 Summary:        Summarize geospatial raster datasets based on vector geometries
 
 License:        Apache License, Version 2.0
-URL:            https://pypi.org/project/rasterstats/
-Source0:        https://files.pythonhosted.org/packages/source/r/rasterstats/rasterstats-%{version}.tar.gz#/python-rasterstats-%{version}.tar.gz
+URL:            https://github.com/perrygeo/python-rasterstats
+Source0:        https://github.com/perrygeo/python-rasterstats/archive/refs/tags/%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  %{python3_vers}-devel
 BuildRequires:  %{python3_vers}-setuptools
+BuildRequires:  %{python3_vers}-affine < 3
+BuildRequires:  %{python3_vers}-shapely
+BuildRequires:  %{python3_vers}-numpy >= 1.9
+BuildRequires:  %{python3_vers}-rasterio >= 1.0
+BuildRequires:  %{python3_vers}-cligj >= 0.4
+BuildRequires:  %{python3_vers}-fiona
+BuildRequires:  %{python3_vers}-simplejson
+BuildRequires:  gdal-devel
+BuildRequires:  python3-pytest
+
+Requires:       %{python3_vers}-affine < 3
+Requires:       %{python3_vers}-shapely
+Requires:       %{python3_vers}-numpy >= 1.9
+Requires:       %{python3_vers}-rasterio >= 1.0
+Requires:       %{python3_vers}-cligj >= 0.4
+Requires:       %{python3_vers}-fiona
+Requires:       %{python3_vers}-simplejson
 
 %description
 Rasterstats is a Python module for summarizing geospatial raster datasets based on vector geometries.
@@ -33,7 +50,7 @@ It includes functions for zonal statistics and interpolated point queries.
 The command-line interface allows for easy interoperability with other GeoJSON tools.
 
 %prep
-%autosetup -n rasterstats-%{version}
+%autosetup -n python-rasterstats-%{version}
 
 %build
 %py3_build
@@ -42,18 +59,16 @@ The command-line interface allows for easy interoperability with other GeoJSON t
 %py3_install
 
 %check
-
-#disabled test to avoid gdal dependency
-#{__python2} setup.py test
-#pushd %{py3dir}
-#{__python3} setup.py test
-#popd
+%pytest -v
 
 %files -n %{python3_vers}-rasterstats
 %{python3_sitelib}/*
 
 
 %changelog
+* Mon Aug 29 2022 Emanuele Di Giacomo <edigiacomo@arpae.it> - 0.17.0-1
+- New version
+
 * Thu Aug 25 2022 Emanuele Di Giacomo <edigiacomo@arpae.it> - 0.13.1-2
 - Removed python 2 support
 


### PR DESCRIPTION
Questa PR aggiorna alla versione 0.17.0, che però non è compatibile con EPEL 8 in quanto manca il pacchetto `python3-rasterio`, disponibile solo per Fedora. Tuttavia, anche la versione attualmente pacchettizzata per EPEL 8 non è poi installabile:

```
$ monci shell rocky8

[root@2a190934-2aee-4552-aa38-3f9a5b7f4fe1 ~]# dnf info python3-rasterstats
Last metadata expiration check: 4:00:53 ago on Mon Aug 29 13:49:13 2022.
Available Packages
Name         : python3-rasterstats
Version      : 0.13.1
Release      : 2.el8
Architecture : noarch
Size         : 33 k
Source       : python-rasterstats-0.13.1-2.el8.src.rpm
Repository   : copr:copr.fedorainfracloud.org:simc:stable
Summary      : Summarize geospatial raster datasets based on vector geometries
URL          : https://pypi.org/project/rasterstats/
License      : Apache License, Version 2.0
Description  : Rasterstats is a Python module for summarizing geospatial raster datasets based on vector geometries.
             : It includes functions for zonal statistics and interpolated point queries.
             : The command-line interface allows for easy interoperability with other GeoJSON tools.

[root@2a190934-2aee-4552-aa38-3f9a5b7f4fe1 ~]# dnf install python3-rasterstats
Last metadata expiration check: 3:59:32 ago on Mon Aug 29 13:49:13 2022.
Error: 
 Problem: conflicting requests
  - nothing provides python3.6dist(rasterio) >= 1.0 needed by python3-rasterstats-0.13.1-2.el8.noarch
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

Fix #1 